### PR TITLE
fix: pnpm v11 のビルドスクリプト承認設定を更新

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,2 @@
-onlyBuiltDependencies:
-  - esbuild
+allowBuilds:
+  esbuild: true


### PR DESCRIPTION
## 概要

pnpm v11 へのアップデートに伴い、ビルドスクリプトの承認設定を更新します。

## 変更内容

pnpm v11 では、セキュリティ向上のためパッケージのビルドスクリプトがデフォルトでブロックされるようになりました。これにより以下のエラーが発生します:

- `[ERR_PNPM_IGNORED_BUILDS]`: `pnpm install` でビルドスクリプトがブロックされる

### 修正

`pnpm-workspace.yaml` の `onlyBuiltDependencies` 形式を pnpm v11 対応の `allowBuilds` 形式に変更します。

## 関連

- book000/book000#108

🤖 Generated with [Claude Code](https://claude.com/claude-code)