### PR TITLE
fix: TypeScript v6 対応のため tsconfig.json を更新

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,11 +2,10 @@
   "compilerOptions": {
     "target": "es2020",
     "module": "commonjs",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "lib": ["ESNext", "esnext.AsyncIterable", "DOM"],
     "rootDir": "./src",
     "outDir": "./dist",
-    "ignoreDeprecations": "6.0",
     "removeComments": true,
     "esModuleInterop": true,
     "allowJs": true,
@@ -24,10 +23,10 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "experimentalDecorators": true,
-    "baseUrl": ".",
     "newLine": "LF",
+    "types": ["node"],
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     }
   },
   "include": ["src/**/*"]


### PR DESCRIPTION
## 概要

TypeScript v6.0 で非推奨となった設定を修正し、TypeScript v7.0 への互換性を確保します。

Fixes #419

## 変更内容

### tsconfig.json

| 設定項目 | 変更前 | 変更後 |
|---------|--------|--------|
| `moduleResolution` | `"Node"` | `"bundler"` |
| `ignoreDeprecations` | `"6.0"` | 削除 |
| `baseUrl` | `"."` | 削除 |
| `paths` | `"@/*": ["src/*"]` | `"@/*": ["./src/*"]` (相対パス) |
| `types` | (未設定) | `["node"]` を追加 |

### 変更の理由

- **`moduleResolution: "Node"` → `"bundler"`**: TypeScript v6.0 で `"Node"` が非推奨となったため、推奨される代替として `"bundler"` に変更
- **`ignoreDeprecations: "6.0"` を削除**: TypeScript v7.0 で機能しなくなるため、根本的な修正を実施
- **`baseUrl` を削除・`paths` を相対パスに更新**: TypeScript v6.0 の `paths` の変更に合わせて相対パスへ移行
- **`types: ["node"]` を追加**: TypeScript v6.0 で `@types/node` の自動ロードが廃止されたため、明示的に指定

## 確認事項

- [x] `pnpm install` 実行済み
- [x] `pnpm exec tsc --noEmit` でビルドエラーなし
- [x] `pnpm lint` (Prettier + ESLint + TypeScript 型チェック) でエラーなし