### PR TITLE
fix: pnpm fetch 前に package.json を COPY するよう Dockerfile を修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,10 +24,11 @@ RUN git clone https://github.com/novnc/noVNC.git /opt/noVNC && \
 WORKDIR /app
 
 COPY pnpm-lock.yaml ./
+COPY package.json ./
 
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm fetch
 
-COPY package.json tsconfig.json ./
+COPY tsconfig.json ./
 COPY src src
 
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile --offline


### PR DESCRIPTION
## 概要

`@book000/eslint-config` の更新 (PR #404) 後に CI の Docker build が失敗していた問題を修正します。

Fixes #423

## 原因

`Dockerfile` では `pnpm fetch` が `package.json` を `COPY` する前に実行されていました。

corepack は `package.json` の `packageManager` フィールド (`pnpm@10.34.2+...`) を参照して使用する pnpm バージョンを決定します。
`package.json` が存在しない状態で `pnpm fetch` を実行すると、corepack が latest (pnpm 11.x) をダウンロードしてしまい、ベースイメージの Node 20.15.1 では `ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING` エラーが発生していました。

## 変更内容

```diff
 COPY pnpm-lock.yaml ./
+COPY package.json ./
 
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm fetch
 
-COPY package.json tsconfig.json ./
+COPY tsconfig.json ./
 COPY src src
```

- `COPY package.json ./` を `pnpm fetch` より前に移動
- `COPY tsconfig.json ./` は `pnpm fetch` の後に残す（依存関係解決に不要なため）

## 確認項目

- [x] `pnpm lint` が通ることを確認
- [x] TypeScript 型チェック (`tsc`) が通ることを確認
- [ ] Docker build が CI で成功することを確認